### PR TITLE
fix: allow commit and push to fail

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -17,12 +17,14 @@ jobs:
       - name: Build
         run: npm run build
       - name: Commit dist files
+        continue-on-error: true
         run: |
           git config --local user.email "ting.szeying@gmail.com"
           git config --local user.name "szenius"
           git add ./dist
           git commit -m "build: update dist files"
       - name: Push changes
+        continue-on-error: true
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
[Notion link](https://www.notion.so/Add-build-before-tagging-in-worflow-ba36bc04336843e692aa2607dee8fcd2)

Because there might not be new build files