### PR TITLE
feat: allow notion urls with domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const updateNotionStory = async (
 
 const extractFirstNotionPageId = (prDescription) => {
   const notionURLs = prDescription.match(
-    /(https?:\/\/)?(www\.)?notion\.so\/([A-Za-z0-9\-]+)/gi
+    /(https?:\/\/)?(www\.)?notion\.so\/([A-Za-z0-9\-\/]+)/gi
   );
   if (notionURLs === null || notionURLs.length === 0) {
     return null;


### PR DESCRIPTION
[Notion link](https://www.notion.so/szenius/Fix-notion-url-can-t-be-found-when-there-s-a-domain-25e5a6a770b448619628c247532c385d)

This PR fixes the notion URL extraction to allow extraction of URLs with domain name.