### PR TITLE
feat: append to current property if it exists and support notion-property-type

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -45,4 +45,5 @@ jobs:
           gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
           notion-key: ${{ secrets.NOTION_KEY }}
           notion-property-name: "Version Tag"
+          notion-property-type: "multi_select"
           notion-update-value: "${{ steps.version.outputs.new_tag }}"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ GitHub action to update a Notion page property on commit created by merging a Pu
 
 Originally built for updating version tag in Notion page on commit. See [the test workflow](.github/workflows/on_master.yml) as an example.
 
+Notes:
+
+- Only able to work on a property that is of type `text`
+- Current appending logic assumes that no formatting is done in the property, i.e. all plain text only
+
 ## Example Usage
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -19,18 +19,10 @@ with:
   notion-update-value: "Merged"
 ```
 
-Required properties
-
 - `gh-username`: GitHub username of user who has access to the repository
 - `gh-token`: GitHub access token of user who has access to the repository
 - `notion-key`: Notion Integration Secret Key
 - `notion-property-name`: Notion Page property to be updated
 - `notion-update-value`: New value for Notion page property
-
-Optional properties:
-
-- `notion-property-type`: Type of Notion Page property
-  - Currently supports type `rich_text` and `multi_select`
-  - Defaults to `rich_text` if not specified
-
+- `notion-property-type` (optional): Type of Notion Page property. Can be `rich_text` or `multi_select`. Defaults to `rich_text`.
 The [test workflow](.github/workflows/on_master.yml) is linked to [this Notion database](https://szenius.notion.site/4964f7c754f54c41abce56028d990ac6?v=9ece5b75d4914584b43685bcbc6f3d1c).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ GitHub action to update a Notion page property on commit created by merging a Pu
 
 Originally built for updating version tag in Notion page on commit. See [the test workflow](.github/workflows/on_master.yml) as an example.
 
-Notes:
-
-- Only able to work on a property that is of type `text`
-- Current appending logic assumes that no formatting is done in the property, i.e. all plain text only
-
 ## Example Usage
 
 ```yml
@@ -20,13 +15,22 @@ with:
   gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
   notion-key: ${{ secrets.NOTION_KEY }}
   notion-property-name: "Status"
+  notion-property-name: "multi_select"
   notion-update-value: "Merged"
 ```
+
+Required properties
 
 - `gh-username`: GitHub username of user who has access to the repository
 - `gh-token`: GitHub access token of user who has access to the repository
 - `notion-key`: Notion Integration Secret Key
 - `notion-property-name`: Notion Page property to be updated
 - `notion-update-value`: New value for Notion page property
+
+Optional properties:
+
+- `notion-property-type`: Type of Notion Page property
+  - Currently supports type `rich_text` and `multi_select`
+  - Defaults to `rich_text` if not specified
 
 The [test workflow](.github/workflows/on_master.yml) is linked to [this Notion database](https://szenius.notion.site/4964f7c754f54c41abce56028d990ac6?v=9ece5b75d4914584b43685bcbc6f3d1c).

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   notion-property-name:
     description: "Notion Page property to be updated"
     required: true
+  notion-property-type:
+    description: "Type of Notion Page property"
+    required: false
   notion-update-value:
     description: "New value for Notion page property"
     required: true

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ const getGitHubRequestHeaders = (username, accessToken) => ({
   headers: { Authorization: `Basic ${btoa(`${username}:${accessToken}`)}` },
 });
 
-const generateUpdateProps = (propertyType, value, pageDetails) => {
+const generateUpdateProps = (propertyType, propertyName, newValue, pageDetails) => {
   if (propertyType === SUPPORTED_PROPERTY_TYPES.RICH_TEXT) {
     const richTextValues = pageDetails.properties[propertyName].rich_text;
-    richTextValues.push(value);
+    richTextValues.push(newValue);
 
     return {
       rich_text: [{ type: "text", text: { content: richTextValues.join(',') } }],
@@ -23,7 +23,7 @@ const generateUpdateProps = (propertyType, value, pageDetails) => {
   }
   else if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {
     const selectValues = pageDetails.properties[propertyName].multi_select;
-    selectValues.push({"name": value});
+    selectValues.push({"name": newValue});
 
     return {
       multi_select: selectValues,
@@ -42,7 +42,7 @@ const updateNotionStory = async (
 
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
 
-  const updateProps = generateUpdateProps(propertyType, value, pageDetails);
+  const updateProps = generateUpdateProps(propertyType, propertyName, value, pageDetails);
 
   await notion.pages.update({
     page_id: notionPageId,

--- a/index.js
+++ b/index.js
@@ -24,28 +24,28 @@ const updateNotionStory = async (
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
 
   if (propertyType === SUPPORTED_PROPERTY_TYPES.RICH_TEXT) {
-    const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
-    existingPropertyValues.push(value);
+    const richTextValues = pageDetails.properties[propertyName].rich_text;
+    richTextValues.push(value);
 
     await notion.pages.update({
       page_id: notionPageId,
       properties: {
         [propertyName]: {
-          rich_text: [{ type: "text", text: { content: existingPropertyValues.join(',') } }],
+          rich_text: [{ type: "text", text: { content: richTextValues.join(',') } }],
         },
       },
     });
   }
 
   if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {
-    const existingPropertyValues = pageDetails.properties[propertyName].multi_select;
-    existingPropertyValues.push({"name": value})
+    const selectValues = pageDetails.properties[propertyName].multi_select;
+    selectValues.push({"name": value});
 
     await notion.pages.update({
       page_id: notionPageId,
       properties: {
         [propertyName]: {
-          multi_select: existingPropertyValues,
+          multi_select: selectValues,
         },
       },
     });

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ const getConfig = () => {
       accessToken: process.env.GH_ACCESS_TOKEN,
       notionKey: process.env.NOTION_KEY,
       notionPropertyName: process.env.NOTION_PROPERTY_NAME,
-      notionPropertyType: process.env.NOTION_PROPERTY_TYPE,
+      notionPropertyType: process.env.NOTION_PROPERTY_TYPE || SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
       notionUpdateValue: process.env.NOTION_UPDATE_VALUE,
     };
   }
@@ -124,7 +124,7 @@ const getConfig = () => {
     accessToken: core.getInput("gh-token"),
     notionKey: core.getInput("notion-key"),
     notionPropertyName: core.getInput("notion-property-name"),
-    notionPropertyType: core.getInput("notion-property-type"),
+    notionPropertyType: core.getInput("notion-property-type") || SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
     notionUpdateValue: core.getInput("notion-update-value"),
   };
 };
@@ -182,7 +182,7 @@ const run = async () => {
       notionPageId,
       notionPropertyName,
       notionUpdateValue,
-      notionPropertyType || SUPPORTED_PROPERTY_TYPES.RICH_TEXT
+      notionPropertyType
     );
   } catch (error) {
     core.setFailed(`Error updating Notion page ${notionPageId}: ${error}`);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { Client } = require("@notionhq/client");
 
 require("dotenv").config();
 
-const supportedPropertyTypes = {"rich_text": "rich_text", "multi_select": "multi_select"};
+const SUPPORTED_PROPERTY_TYPES = {"RICH_TEXT": "rich_text", "MULTI_SELECT": "multi_select"};
 
 const getGitHubRequestHeaders = (username, accessToken) => ({
   headers: { Authorization: `Basic ${btoa(`${username}:${accessToken}`)}` },
@@ -23,7 +23,7 @@ const updateNotionStory = async (
 
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
 
-  if (propertyType === supportedPropertyTypes.rich_text) {
+  if (propertyType === SUPPORTED_PROPERTY_TYPES.RICH_TEXT) {
     const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
   
     if (existingPropertyValues.length === 0) {
@@ -49,7 +49,7 @@ const updateNotionStory = async (
     }
   }
 
-  if (propertyType === supportedPropertyTypes.multi_select) {
+  if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {
     const existingPropertyValues = pageDetails.properties[propertyName].multi_select;
     existingPropertyValues.push({"name": value})
 
@@ -154,7 +154,7 @@ const run = async () => {
     notionUpdateValue,
   } = getConfig();
 
-  if (!(notionPropertyType in supportedPropertyTypes)) {
+  if (!(notionPropertyType in SUPPORTED_PROPERTY_TYPES)) {
     core.setFailed(
       `Type of Notion Page property ${notionPropertyType} is not supported.`
     );
@@ -194,7 +194,7 @@ const run = async () => {
       notionPageId,
       notionPropertyName,
       notionUpdateValue,
-      notionPropertyType || supportedPropertyTypes.rich_text
+      notionPropertyType || SUPPORTED_PROPERTY_TYPES.RICH_TEXT
     );
   } catch (error) {
     core.setFailed(`Error updating Notion page ${notionPageId}: ${error}`);

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ const run = async () => {
     notionUpdateValue,
   } = getConfig();
 
-  if (!(notionPropertyType in SUPPORTED_PROPERTY_TYPES)) {
+  if (!(SUPPORTED_PROPERTY_TYPES.hasOwnProperty(notionPropertyType.toUpperCase()))) {
     core.setFailed(
       `Type of Notion Page property ${notionPropertyType} is not supported.`
     );

--- a/index.js
+++ b/index.js
@@ -17,14 +17,32 @@ const updateNotionStory = async (
   value
 ) => {
   const notion = new Client({ auth: notionKey });
-  await notion.pages.update({
-    page_id: notionPageId,
-    properties: {
-      [propertyName]: {
-        rich_text: [{ type: "text", text: { content: value } }],
+
+  const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
+  
+  const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
+
+  if (existingPropertyValues.length === 0) {
+    await notion.pages.update({
+      page_id: notionPageId,
+      properties: {
+        [propertyName]: {
+          rich_text: [{ type: "text", text: { content: value } }],
+        },
       },
-    },
-  });
+    });
+  } else {
+    const existingValue = existingPropertyValues[0].plain_text;
+    const combinedValue = `${existingValue},${value}`;
+    await notion.pages.update({
+      page_id: notionPageId,
+      properties: {
+        [propertyName]: {
+          rich_text: [{ type: "text", text: { content: combinedValue } }],
+        },
+      },
+    });
+  }
 };
 
 const extractFirstNotionPageId = (prDescription) => {

--- a/index.js
+++ b/index.js
@@ -25,28 +25,16 @@ const updateNotionStory = async (
 
   if (propertyType === SUPPORTED_PROPERTY_TYPES.RICH_TEXT) {
     const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
-  
-    if (existingPropertyValues.length === 0) {
-      await notion.pages.update({
-        page_id: notionPageId,
-        properties: {
-          [propertyName]: {
-            rich_text: [{ type: "text", text: { content: value } }],
-          },
+    existingPropertyValues.push(value);
+
+    await notion.pages.update({
+      page_id: notionPageId,
+      properties: {
+        [propertyName]: {
+          rich_text: [{ type: "text", text: { content: existingPropertyValues.join(',') } }],
         },
-      });
-    } else {
-      const existingValue = existingPropertyValues[0].plain_text;
-      const combinedValue = `${existingValue},${value}`;
-      await notion.pages.update({
-        page_id: notionPageId,
-        properties: {
-          [propertyName]: {
-            rich_text: [{ type: "text", text: { content: combinedValue } }],
-          },
-        },
-      });
-    }
+      },
+    });
   }
 
   if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {

--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ const getConfig = () => {
       accessToken: process.env.GH_ACCESS_TOKEN,
       notionKey: process.env.NOTION_KEY,
       notionPropertyName: process.env.NOTION_PROPERTY_NAME,
+      notionPropertyType: process.env.NOTION_PROPERTY_TYPE,
       notionUpdateValue: process.env.NOTION_UPDATE_VALUE,
     };
   }
@@ -115,11 +116,14 @@ const getConfig = () => {
     accessToken: core.getInput("gh-token"),
     notionKey: core.getInput("notion-key"),
     notionPropertyName: core.getInput("notion-property-name"),
+    notionPropertyType: core.getInput("notion-property-type"),
     notionUpdateValue: core.getInput("notion-update-value"),
   };
 };
 
 const run = async () => {
+  const supportedPropertyTypes = ["rich_text", "multi_select"];
+
   const {
     commitHash,
     repoOwner,
@@ -128,8 +132,15 @@ const run = async () => {
     accessToken,
     notionKey,
     notionPropertyName,
+    notionPropertyType,
     notionUpdateValue,
   } = getConfig();
+
+  if (!(notionPropertyType in supportedPropertyTypes)) {
+    core.setFailed(
+      `Type of Notion Page property ${notionPropertyType} is not supported.`
+    );
+  }
 
   let prDescription = "";
   try {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const { Client } = require("@notionhq/client");
 
 require("dotenv").config();
 
+const supportedPropertyTypes = {"rich_text": "rich_text", "multi_select": "multi_select"};
+
 const getGitHubRequestHeaders = (username, accessToken) => ({
   headers: { Authorization: `Basic ${btoa(`${username}:${accessToken}`)}` },
 });
@@ -14,35 +16,53 @@ const updateNotionStory = async (
   notionKey,
   notionPageId,
   propertyName,
-  value
+  value,
+  propertyType
 ) => {
   const notion = new Client({ auth: notionKey });
 
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
-  
-  const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
 
-  if (existingPropertyValues.length === 0) {
-    await notion.pages.update({
-      page_id: notionPageId,
-      properties: {
-        [propertyName]: {
-          rich_text: [{ type: "text", text: { content: value } }],
+  if (propertyType === supportedPropertyTypes.rich_text) {
+    const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
+  
+    if (existingPropertyValues.length === 0) {
+      await notion.pages.update({
+        page_id: notionPageId,
+        properties: {
+          [propertyName]: {
+            rich_text: [{ type: "text", text: { content: value } }],
+          },
         },
-      },
-    });
-  } else {
-    const existingValue = existingPropertyValues[0].plain_text;
-    const combinedValue = `${existingValue},${value}`;
+      });
+    } else {
+      const existingValue = existingPropertyValues[0].plain_text;
+      const combinedValue = `${existingValue},${value}`;
+      await notion.pages.update({
+        page_id: notionPageId,
+        properties: {
+          [propertyName]: {
+            rich_text: [{ type: "text", text: { content: combinedValue } }],
+          },
+        },
+      });
+    }
+  }
+
+  if (propertyType === supportedPropertyTypes.multi_select) {
+    const existingPropertyValues = pageDetails.properties[propertyName].multi_select;
+    existingPropertyValues.push({"name": value})
+
     await notion.pages.update({
       page_id: notionPageId,
       properties: {
         [propertyName]: {
-          rich_text: [{ type: "text", text: { content: combinedValue } }],
+          multi_select: existingPropertyValues,
         },
       },
     });
   }
+  
 };
 
 const extractFirstNotionPageId = (prDescription) => {
@@ -122,8 +142,6 @@ const getConfig = () => {
 };
 
 const run = async () => {
-  const supportedPropertyTypes = ["rich_text", "multi_select"];
-
   const {
     commitHash,
     repoOwner,
@@ -175,7 +193,8 @@ const run = async () => {
       notionKey,
       notionPageId,
       notionPropertyName,
-      notionUpdateValue
+      notionUpdateValue,
+      notionPropertyType || supportedPropertyTypes.rich_text
     );
   } catch (error) {
     core.setFailed(`Error updating Notion page ${notionPageId}: ${error}`);


### PR DESCRIPTION
[Notion link](https://www.notion.so/szenius/Allow-append-to-field-90d9312ba0cd44619e5b2f2391e2fab8)

This PR 
- appends the new property value to the current property value if it exists. 
- create a new field called `notion-property-type` that can be used to specify 2 different types of updates
- updates README :D 

### Test results from running on my personal Notion and GitHub actions, when the type was `rich_text`

**First version tag created**
![first-version-tag](https://user-images.githubusercontent.com/5070244/152386230-ee8e5aa1-5d28-4a7a-9fcc-9a0fbc1e16a4.png)

**Second version tag is appended after the first version tag**
![second-version-tag](https://user-images.githubusercontent.com/5070244/152386244-57ca6f38-0e93-436d-b030-7fc97a377b51.png)

### Test results from running on my personal Notion and GitHub actions, when the type was `multi_select`
**New version tag is added to the existing multi_select**
Note that I realised that I didn't update the action.yml, hence there's a warning here haha
![Screenshot 2022-02-04 at 7 48 02 PM](https://user-images.githubusercontent.com/5070244/152524181-e84a7574-33a9-4717-8a0f-fe95592f5214.png)

**Clearing out all the current values in multi_select to check that the first tag will be successfully added**
I used the PR that fixed the warning above, hence it's gone here haha
![Screenshot 2022-02-04 at 9 38 46 PM](https://user-images.githubusercontent.com/5070244/152538453-3f4e3820-eddc-4720-9e41-fa7455cbe241.png)

