### PR TITLE
build: remove notion-property-type

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -45,5 +45,4 @@ jobs:
           gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
           notion-key: ${{ secrets.NOTION_KEY }}
           notion-property-name: "Version Tag"
-          notion-property-type: "multi_select"
           notion-update-value: "${{ steps.version.outputs.new_tag }}"


### PR DESCRIPTION
[Notion link](https://www.notion.so/szenius/Allow-append-to-field-90d9312ba0cd44619e5b2f2391e2fab8)

This PR removes the notion-property-type, as the default is rich_text, which is what is needed on master.

Fixes the work for #17 


