### PR TITLE
feat: also allow overwrite instead of append

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Originally built for updating version tag in Notion page on commit. See [the tes
 ## Example Usage
 
 ```yml
-uses: szenius/notion-update-page@1.1.10
+uses: szenius/notion-update-page@1.1.11
 with:
   gh-username: "username"
   gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -25,5 +25,8 @@ with:
 - `notion-property-name`: Notion Page property to be updated
 - `notion-update-value`: New value for Notion page property
 - `notion-property-type` (optional): Type of Notion Page property. Can be `rich_text` or `multi_select`. Defaults to `rich_text`.
+- `existing-value` (optional): What to do with existing value in field to be updated. Can be `append` or `overwrite`. Defaults to
+  - `overwrite` if `notion-property-type` is `multi_select`
+  - `append` if `notion-property-type` is `rich_text`
 
 The [test workflow](.github/workflows/on_master.yml) is linked to [this Notion database](https://szenius.notion.site/4964f7c754f54c41abce56028d990ac6?v=9ece5b75d4914584b43685bcbc6f3d1c).

--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,17 @@ inputs:
   notion-property-name:
     description: "Notion Page property to be updated"
     required: true
-  notion-property-type:
-    description: "Type of Notion Page property"
-    required: false
   notion-update-value:
     description: "New value for Notion page property"
     required: true
+  existing-value:
+    description: "What to do if the field to be updated already has existing values"
+    required: false
+    default: "overwrite"
+  notion-property-type:
+    description: "Type of Notion Page property"
+    required: false
+    default: "rich_text"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -6,43 +6,69 @@ const { Client } = require("@notionhq/client");
 
 require("dotenv").config();
 
-const SUPPORTED_PROPERTY_TYPES = {"RICH_TEXT": "rich_text", "MULTI_SELECT": "multi_select"};
+const SUPPORTED_PROPERTY_TYPES = {
+  RICH_TEXT: "rich_text",
+  MULTI_SELECT: "multi_select",
+};
+
+const SUPPORTED_EXISTING_VALUE_ACTIONS = {
+  OVERWRITE: "overwrite",
+  APPEND: "append",
+};
 
 const getGitHubRequestHeaders = (username, accessToken) => ({
   headers: { Authorization: `Basic ${btoa(`${username}:${accessToken}`)}` },
 });
 
-const generateUpdateProps = (propertyType, propertyName, newValue, pageDetails) => {
-  if (propertyType === SUPPORTED_PROPERTY_TYPES.RICH_TEXT) {
-    const richTextValues = pageDetails.properties[propertyName].rich_text;
-    richTextValues.push(newValue);
-
-    return {
-      rich_text: [{ type: "text", text: { content: richTextValues.join(',') } }],
-    };
-  }
-  else if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {
+const generateUpdateProps = (
+  propertyType,
+  existingValueAction,
+  propertyName,
+  newValue,
+  pageDetails
+) => {
+  if (propertyType === SUPPORTED_PROPERTY_TYPES.MULTI_SELECT) {
     const selectValues = pageDetails.properties[propertyName].multi_select;
-    selectValues.push({"name": newValue});
+    selectValues.push({ name: newValue });
 
     return {
       multi_select: selectValues,
     };
   }
-}
+
+  if (existingValueAction === SUPPORTED_EXISTING_VALUE_ACTIONS.OVERWRITE) {
+    return {
+      rich_text: [{ type: "text", text: { content: newValue } }],
+    };
+  }
+
+  const richTextValues = pageDetails.properties[propertyName].rich_text;
+  richTextValues.push(newValue);
+
+  return {
+    rich_text: [{ type: "text", text: { content: richTextValues.join(",") } }],
+  };
+};
 
 const updateNotionStory = async (
   notionKey,
   notionPageId,
   propertyName,
   value,
-  propertyType
+  propertyType,
+  existingValueAction
 ) => {
   const notion = new Client({ auth: notionKey });
 
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
 
-  const updateProps = generateUpdateProps(propertyType, propertyName, value, pageDetails);
+  const updateProps = generateUpdateProps(
+    propertyType,
+    existingValueAction,
+    propertyName,
+    value,
+    pageDetails
+  );
 
   await notion.pages.update({
     page_id: notionPageId,
@@ -111,8 +137,12 @@ const getConfig = () => {
       accessToken: process.env.GH_ACCESS_TOKEN,
       notionKey: process.env.NOTION_KEY,
       notionPropertyName: process.env.NOTION_PROPERTY_NAME,
-      notionPropertyType: process.env.NOTION_PROPERTY_TYPE || SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
+      notionPropertyType:
+        process.env.NOTION_PROPERTY_TYPE || SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
       notionUpdateValue: process.env.NOTION_UPDATE_VALUE,
+      existingValueAction:
+        process.env.EXISTING_VALUE ||
+        SUPPORTED_EXISTING_VALUE_ACTIONS.OVERWRITE,
     };
   }
   return {
@@ -123,8 +153,13 @@ const getConfig = () => {
     accessToken: core.getInput("gh-token"),
     notionKey: core.getInput("notion-key"),
     notionPropertyName: core.getInput("notion-property-name"),
-    notionPropertyType: core.getInput("notion-property-type") || SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
+    notionPropertyType:
+      core.getInput("notion-property-type") ||
+      SUPPORTED_PROPERTY_TYPES.RICH_TEXT,
     notionUpdateValue: core.getInput("notion-update-value"),
+    existingValueAction:
+      core.getInput("existing-value") ||
+      SUPPORTED_EXISTING_VALUE_ACTIONS.OVERWRITE,
   };
 };
 
@@ -139,9 +174,12 @@ const run = async () => {
     notionPropertyName,
     notionPropertyType,
     notionUpdateValue,
+    existingValueAction,
   } = getConfig();
 
-  if (!(SUPPORTED_PROPERTY_TYPES.hasOwnProperty(notionPropertyType.toUpperCase()))) {
+  if (
+    !SUPPORTED_PROPERTY_TYPES.hasOwnProperty(notionPropertyType.toUpperCase())
+  ) {
     core.setFailed(
       `Type of Notion Page property ${notionPropertyType} is not supported.`
     );
@@ -181,7 +219,8 @@ const run = async () => {
       notionPageId,
       notionPropertyName,
       notionUpdateValue,
-      notionPropertyType
+      notionPropertyType,
+      existingValueAction
     );
   } catch (error) {
     core.setFailed(`Error updating Notion page ${notionPageId}: ${error}`);


### PR DESCRIPTION
[Notion link](https://www.notion.so/szenius/Allow-append-to-field-90d9312ba0cd44619e5b2f2391e2fab8)

This PR makes the default action for dealing with existing values "overwrite" instead of "append" to keep it backward compatible.