### PR TITLE
Update actions/checkout@v2 to v3

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update Notion property
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         run: npm ci
       - name: Build


### PR DESCRIPTION

This PR updates the actions/checkout@v2 to v3 to solve the Node12 JS deprecation warning

